### PR TITLE
fix: Update default page_size in get_task_data function

### DIFF
--- a/sprintspace/api/tasks.py
+++ b/sprintspace/api/tasks.py
@@ -15,7 +15,7 @@ KANBAN_LIST = [
 ]
 
 
-def get_task_data(project: str, page: int = 1, page_size: int = 50) -> List[Dict[Any, Any]]:
+def get_task_data(project: str, page: int = 1, page_size: int = 9999) -> List[Dict[Any, Any]]:
     """Get tasks with related data in optimized queries"""
     try:
         # Calculate pagination


### PR DESCRIPTION
- Changed the default value of the page_size parameter from 50 to 9999 in the get_task_data function to allow for retrieving more tasks in a single query.
- This adjustment aims to optimize data retrieval for larger projects.