### PR TITLE
fix: Update default page_size in get_tasks function

### DIFF
--- a/sprintspace/api/tasks.py
+++ b/sprintspace/api/tasks.py
@@ -135,7 +135,7 @@ def get_task_data(project: str, page: int = 1, page_size: int = 9999) -> List[Di
 
 @frappe.whitelist()
 # @redis_cache(ttl=300)  # Cache for 5 minutes
-def get_tasks(project: str, page: int = 1, page_size: int = 50) -> Dict[str, Any]:
+def get_tasks(project: str, page: int = 1, page_size: int = 9999) -> Dict[str, Any]:
     """
     Get tasks for a project with pagination and caching
     Args:


### PR DESCRIPTION
- Changed the default value of the page_size parameter from 50 to 9999 in the get_tasks function to align with the updated pagination strategy.
- This modification enhances the ability to retrieve a larger set of tasks per request, improving efficiency for project management.